### PR TITLE
Add Docker Compose and multi-stage Dockerfiles for microservices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Etapa 1: Build (compilación de en el proyecto)
+FROM maven:3.9.0-eclipse-temurin-17 AS build
+
+# Directorio de trabajo dentro del contenedor de build
+WORKDIR /app
+
+# Copiar en el proyecto al contenedor
+COPY . .
+
+# Construir en el proyecto y empaquetar los JARs (sin tests para acelerar)
+RUN mvn clean install -DskipTests
+
+# --- Etapas de imagen final para cada servicio ---
+
+# api-gateway
+FROM eclipse-temurin:17-jre AS api-gateway
+WORKDIR /app
+COPY --from=build /app/api-gateway/target/api-gateway-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/app.jar"]
+
+# auth-service
+FROM eclipse-temurin:17-jre AS auth-service
+WORKDIR /app
+COPY --from=build /app/auth-service/target/auth-service-1.0.0.jar app.jar
+EXPOSE 8083
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/app.jar"]
+
+# eureka-server
+FROM eclipse-temurin:17-jre AS eureka-server
+WORKDIR /app
+COPY --from=build /app/eureka-server/target/eureka-server-1.0.0.jar app.jar
+EXPOSE 8761
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/app.jar"]
+
+# inventory-service
+FROM eclipse-temurin:17-jre AS inventory-service
+WORKDIR /app
+COPY --from=build /app/inventory-service/target/inventory-service-1.0.0.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/app.jar"]
+
+# order-service
+FROM eclipse-temurin:17-jre AS order-service
+WORKDIR /app
+COPY --from=build /app/order-service/target/order-service-1.0.0.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/app.jar"]

--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -77,6 +77,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <excludes>
                         <exclude>

--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -74,6 +74,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,69 @@
+version: '3.8'
+services:
+  eureka-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: eureka-server
+    image: cleverjohann/eureka-server:1.0.0
+    ports:
+      - "8761:8761"
+    environment:
+      - EUREKA_CLIENT_REGISTER-WITH-EUREKA=false
+      - EUREKA_CLIENT_FETCH-REGISTRY=false
+
+  auth-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: auth-service
+    image: cleverjohann/auth-service:1.0.0
+    ports:
+      - "8083:8083"
+    depends_on:
+      - eureka-server
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
+
+  inventory-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: inventory-service
+    image: cleverjohann/inventory-service:1.0.0
+    ports:
+      - "8082:8082"
+    depends_on:
+      - eureka-server
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
+
+  order-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: order-service
+    image: cleverjohann/order-service:1.0.0
+    ports:
+      - "8081:8081"
+    depends_on:
+      - eureka-server
+      - inventory-service
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka
+
+  api-gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: api-gateway
+    image: cleverjohann/api-gateway:1.0.0
+    ports:
+      - "8080:8080"
+    depends_on:
+      - eureka-server
+      - auth-service
+      - order-service
+      - inventory-service
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://eureka-server:8761/eureka

--- a/inventory-service/pom.xml
+++ b/inventory-service/pom.xml
@@ -73,6 +73,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/order-service/pom.xml
+++ b/order-service/pom.xml
@@ -77,6 +77,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This pull request introduces Docker support for the multi-service Spring Boot project, enabling containerized builds and orchestration with Docker Compose. The changes include a multi-stage `Dockerfile` for building and packaging each service, a new `docker-compose.yml` for local development and integration, and updates to each service's Maven configuration to ensure proper JAR packaging for Docker deployment.

**Containerization and orchestration:**

* Added a multi-stage `Dockerfile` that builds all services using Maven and creates separate images for `api-gateway`, `auth-service`, `eureka-server`, `inventory-service`, and `order-service`, each with its own runtime configuration and exposed port.
* Introduced a new `docker-compose.yml` to orchestrate all services locally, defining build targets, images, ports, dependencies, and required environment variables for service discovery and registration.

**Build and packaging improvements:**

* Updated the `spring-boot-maven-plugin` configuration in each service's `pom.xml` (`api-gateway`, `auth-service`, `inventory-service`, `order-service`) to explicitly add a `repackage` goal, ensuring JARs are properly built for Docker usage. [[1]](diffhunk://#diff-2de7d8b7d626ba600bb44d8f7f286fbbbf2f2408bbefa1407c2401d05927629fR80-R86) [[2]](diffhunk://#diff-4711c6c41d5fb40680eb715553e82168cb54ff78c051a57472ebb5fe537098e4R77-R83) [[3]](diffhunk://#diff-f4842c680ba537f60c24f9612a008c4c5ab694d88d365a0b3dba7c93ffef912cR76-R82) [[4]](diffhunk://#diff-a63cbd3331022eba1c44c95751f16366cc985cf8c033bbdc5f81fb2ce23db80eR80-R86)- Introduced `docker-compose.yml` to orchestrate services: Eureka Server, API Gateway, Auth, Order, and Inventory Services.
- Added multi-stage Dockerfiles for each microservice to build and run containerized Java applications.
- Updated build configurations in `pom.xml` files to include `repackage` Maven goal.